### PR TITLE
Disqus & tags separation

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -23,7 +23,7 @@ class PostForm(djangoforms.ModelForm):
       'cols': 20}))
   body_markup = forms.ChoiceField(
     choices=[(k, v[0]) for k, v in markup.MARKUP_MAP.iteritems()])
-  tags = forms.CharField(widget=forms.Textarea(attrs={'rows': 5, 'cols': 20}))
+  tags = forms.CharField(widget=forms.Textarea(attrs={'rows': 5, 'cols': 20}), label='Tags (one per line)')
   draft = forms.BooleanField(required=False)
   class Meta:
     model = models.BlogPost

--- a/themes/default/post.html
+++ b/themes/default/post.html
@@ -31,6 +31,11 @@
       </script>
     {% endif %}
     <script type="text/javascript" src="http://disqus.com/forums/{{config.disqus_forum}}/embed.js"></script>
+    <script type="text/javascript">
+      disqus_identifier = 'post_{{post.key}}';
+      disqus_url = '{{config.url_prefix}}{{post.path}}';
+      disqus_title = '{{post.title}}';
+    </script>
     <noscript><a href="http://disqus.com/forums/{{config.disqus_forum}}/?url=ref">View the discussion thread.</a></noscript>
     <a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
   {% endif %}


### PR DESCRIPTION
## Disqus setup

From [install instructions](http://docs.disqus.com/developers/universal/):

> disqus_shortname tells Disqus which website account (called a forum on Disqus) this system belongs to.
> 
> disqus_identifier tells Disqus how to uniquely identify the current page.
> 
> disqus_url tells Disqus the location of the page for permalinking purposes.
> 
> There are many more configuration variables available, but these are the most important.

Shortname is already ok.
Identifier was set to `'post_' + post.key`
Url was set to the full post path as recommended
Thread title was set to the same as the post title

[Full vars doc](http://docs.disqus.com/help/2/)
## Tags separation

I never found out what the separator was until I got a bit deep in the code. Added text in post edit tags field to explain separation by line break.
