### PR TITLE
Revert "Add 'skip_files' possibility into app.yaml"

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,18 +3,6 @@ version: live
 runtime: python
 api_version: 1
 
-skip_files: |
- ^(.*/)?(
- (app\.yaml)|
- (app\.yml)|
- (index\.yaml)|
- (index\.yml)|
- (#.*#)|
- (.*~)|
- (.*\.py[co])|
- )$
-
-
 handlers:
 - url: /remote_api
   script: $PYTHON_LIB/google/appengine/ext/remote_api/handler.py


### PR DESCRIPTION
This reverts commit d667799e323827d10ed4d811f9c08f356397d5bc.

By default, skip_files is already set (see [the docs](http://code.google.com/appengine/docs/python/config/appconfig.html#Skipping_Files) for the default value) - our definition is less comprehensive then the default and misses out some files, marking them for uploading by the GAE SDK - for example, the `.git` repository.
